### PR TITLE
Refactoring folder structure of execution-manger to template-manager

### DIFF
--- a/product/distribution/src/assembly/bin.xml
+++ b/product/distribution/src/assembly/bin.xml
@@ -745,7 +745,7 @@
             <source>
                 src/repository/conf/domain-template/temperature-analysis.xml
             </source>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/cep/domain-template</outputDirectory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/template-manager/domain-template</outputDirectory>
             <filtered>true</filtered>
         </file>
 


### PR DESCRIPTION
This is due to renaming the folder structure of execution manger to template manager. Please review and merge.